### PR TITLE
Add support for `puppet cert clean`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ signing of Puppet client certificates via an API call, by passing the
 
 You can configure the shared secret via the `config.yml` file in the `config` directory.
 
+## Cleaning out an old cert
+To revoke and remove a cert from Puppet's CA
+
+    $ curl -d 'secret=SHAREDSECRET' -d 'certname=bob' -X DELETE http://localhost:4567/api/cert
+
 ## Running standalone
 Simply run the ``bundle`` and then ``rackup`` commands. 
 

--- a/lib/psigner/app.rb
+++ b/lib/psigner/app.rb
@@ -32,6 +32,17 @@ module Psigner
       'You need to POST API signing requests'
     end
 
+    delete '/api/cert' do
+      authenticated_only!
+      requires_param :certname
+
+      success, output = clean_cert(params[:certname])
+      unless success
+        halt 500, {'Content-Type' => 'text/plain'}, output
+      end
+      "OK"
+    end
+
     helpers do
       def authenticated_only!
         unless params[:secret] == APP_CONFIG['secret']
@@ -57,6 +68,11 @@ module Psigner
           return "Signing failed because: #{e}"
         end
         signed
+      end
+
+      def clean_cert(certname)
+        stdout = `puppet cert clean #{certname}`
+        [$?.exitstatus == 0, stdout]
       end
     end
   end


### PR DESCRIPTION
Ripped all the reusable stuff out of the existing route and created a new route to revoke and remove certs.  Went with DELETE on /api/cert, felt more restful (thoughts on changing the existing route for signing to POST on /api/cert?)
